### PR TITLE
Optimize the Css cache

### DIFF
--- a/importCss.js
+++ b/importCss.js
@@ -22,11 +22,15 @@ module.exports = function(chunkName) {
 
     return
   }
-  
-  if (ADDED[href] === true) {
+
+  if (ADDED[href] === 'pending') {
+    return Promise.reject();
+  }
+  if (ADDED[href] === 'resolved') {
     return Promise.resolve();
   }
-  ADDED[href] = true;
+
+  ADDED[href] = 'pending';
 
   var head = document.getElementsByTagName('head')[0]
   var link = document.createElement('link')
@@ -44,6 +48,7 @@ module.exports = function(chunkName) {
       link.onerror = link.onload = null // avoid mem leaks in IE.
       clearTimeout(timeout)
       var message = 'could not load css chunk:${chunkName}'
+      ADDED[href] = 'rejected';
       reject(new Error(message))
     }
 
@@ -53,6 +58,7 @@ module.exports = function(chunkName) {
     img.onerror = function() {
       link.onerror = img.onerror = null // avoid mem leaks in IE.
       clearTimeout(timeout)
+      ADDED[href] = 'resolved';
       resolve()
     }
 


### PR DESCRIPTION
in some scenario,   code 
```
Promise.all([
  import( /* webpackChunkName: 'Foo' */ './Foo'),
  importCss('Foo')
]).then(promises => promises[0]);
```
will be execute multiple In a short time. For example, react render multiple when a state changed.

in the file `importCss.js`:
the first time fetch xx.css is pending, and the second time fetch xx.css will hit the cache `ADDED[href] =true`  then resovle directly.   as a matter of fact the xx.css is not loaded with FOUC out.

ADDED[href] =true should be add until  xx.css be resolved or more

