### PR TITLE
feat: Add ability to silence warning for missing css chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ If you don't wanna do that, you can dig through your webpack stats and manually 
 ```
 **Or if you already use the [html-webpack-plugin](https://webpack.js.org/plugins/html-webpack-plugin/) as part of your build process, take a look at the [flush-chunks-html](https://github.com/m4r1vs/webpack-flush-chunks-html) plugin for webpack. It identifies all your generated css-chunks and adds them to your html file like shown above during build!**
 
+In development, a warning will be logged if there are any JS bundles dynamically imported which are not associated with a css chunk in __CSS_CHUNKS__. 
+This warning can be silenced by setting the CSS chunk path for a module to `no-css-chunk-expected`. For instance:
+
+```html
+<script>
+  window.__CSS_CHUNKS__ = {
+    'base/Page1': '/static/base/Page1.css',
+    'some-module': 'no-css-chunk-expected',
+  }
+</script>
+```
+
 ## Usage with [react-universal-component](https://github.com/faceyspacey/react-universal-component) and [webpack-flush-chunks](https://github.com/faceyspacey/webpack-flush-chunks)
 
 When using `webpack-flush-chunks` you will have to supply the `chunkNames` option, not the `moduleIds` option since this plugin is based on chunk names. Here's an example:

--- a/importCss.js
+++ b/importCss.js
@@ -1,32 +1,37 @@
 /* eslint-disable */
 
-var ADDED = {};
+var ADDED = {}
+var NO_CSS_CHUNK_EXPECTED = 'no-css-chunk-expected'
 
 module.exports = function(chunkName) {
   var href = getHref(chunkName)
+
+  if (href === NO_CSS_CHUNK_EXPECTED) {
+    return
+  }
+
   if (!href) {
     if (process.env.NODE_ENV === 'development') {
       if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) {
         console.warn(
           '[DUAL-IMPORT] no css chunks hash found at "window.__CSS_CHUNKS__"'
         )
-        return
+      } else {
+        console.warn(
+          '[DUAL-IMPORT] no chunk, ',
+          chunkName,
+          ', found in "window.__CSS_CHUNKS__"'
+        )
       }
-
-      console.warn(
-        '[DUAL-IMPORT] no chunk, ',
-        chunkName,
-        ', found in "window.__CSS_CHUNKS__"'
-      )
     }
 
     return
   }
-  
+
   if (ADDED[href] === true) {
-    return Promise.resolve();
+    return Promise.resolve()
   }
-  ADDED[href] = true;
+  ADDED[href] = true
 
   var head = document.getElementsByTagName('head')[0]
   var link = document.createElement('link')


### PR DESCRIPTION
When pulling in external modules, often there is no css to go along with the async JS chunk that is
dynamically imported. For these cases, there should be a way to silence the warning that is logged
in development about missing CSS chunks.